### PR TITLE
Make shm_open work

### DIFF
--- a/fedora-toolbox
+++ b/fedora-toolbox
@@ -27,6 +27,7 @@ toolbox_prompt="🔹[\u@\h \W]\\$ "
 
 create()
 (
+    tmpfs_size=$((64 * 1024 * 1024)) # 64 MiB
     working_container_name="fedora-toolbox-working-container-$(uuidgen --time)"
 
     if ! $prefix_sudo buildah inspect --type image $toolbox_image >/dev/null 2>&42; then
@@ -107,9 +108,15 @@ create()
         exit 1
     fi
 
+    total_ram=$(awk '( $1 == "MemTotal:" ) { print $2 }' /proc/meminfo 2>&42) # kibibytes
+    if [ "$total_ram" != "" ] && [ $total_ram -eq $total_ram 2>&42 ]; then
+        tmpfs_size=$((total_ram*1024/2)) # bytes
+    fi
+
     max_uid_count=65536
     max_minus_uid=$((max_uid_count-UID))
     uid_plus_one=$((UID+1))
+
     if ! $prefix_sudo podman create \
                  --group-add wheel \
                  --hostname toolbox \
@@ -118,6 +125,7 @@ create()
                  --network host \
                  --privileged \
                  --security-opt label=disable \
+                 --tmpfs /dev/shm:size=$tmpfs_size \
                  --tty \
                  --uidmap $UID:0:1 \
                  --uidmap 0:1:$UID \


### PR DESCRIPTION
Rootless podman shuld mount a tmpfs at /dev/shm by default. Until that
happens, it's worked around by explicitly specifying the mount point.
Also, the --shm-size flag isn't working with rootless podman [1], so
--tmpfs is used instead.

It tries to mimic the in-kernel tmpfs default [2] of using half the
amount of total RAM. If for some reason /proc/meminfo can't be parsed,
it falls back to using podman's default of 65536k for tmpfs. It's not
clear whether podman uses kibibytes or kilobytes for 'k'. The former
was picked here for consistency.

[1] https://github.com/containers/libpod/issues/1770
[2] https://www.kernel.org/doc/Documentation/filesystems/tmpfs.txt

https://github.com/debarshiray/fedora-toolbox/issues/9