### PR TITLE
Avoid spooky root-like behaviour for non-root interactive shells

### DIFF
--- a/fedora-toolbox
+++ b/fedora-toolbox
@@ -238,7 +238,7 @@ enter()
             --interactive \
             --tty \
             $toolbox_container \
-            /bin/sh -c 'cd "$1"; export PS1="$2"; shift 2; exec "$@"' \
+            capsh --caps="" -- -c 'cd "$1"; export PS1="$2"; shift 2; exec "$@"' \
                     /bin/sh \
                     "$PWD" \
                     "$toolbox_prompt" \


### PR DESCRIPTION
Currently, the non-root interactive shells were being spawned with a
full set of capabilities. This led to unexpected root-like behaviour
for non-root users. All capability sets, except the Permitted (or
CapBnd) set, should be cleared to match the usual state of a host
interactive shell for non-root users.

It doesn't look like podman offers a way to forward CapBnd from the
host without touching the other sets. If '--privileged' is used with
'podman create', then it forwards CapBnd but also initializes the
others to have a full set of capabilities. If it's not used, then it
doesn't touch anything other than CapBnd, but only forwards a subset
of the host's CapBnd, which means that using sudo to attain elevated
privileges inside the toolbox won't give the full set of capabilities
as on the host.

It might be so that having a smaller CapBnd actually doesn't matter.
However, until that's proven true, it's safer to insist on having
'--privileged' forward the full set, and then clear up the other sets
on our own.

https://github.com/debarshiray/fedora-toolbox/issues/16